### PR TITLE
ReadDirect() fix

### DIFF
--- a/RP1210/J1939.py
+++ b/RP1210/J1939.py
@@ -8,7 +8,7 @@ copyright of SAE.
 
 from RP1210 import sanitize_msg_param
 
-def toJ1939Message(pgn, priority, source, destination, data) -> bytes:
+def toJ1939Message(pgn, priority, source, destination, data, data_size = 0) -> bytes:
     """
     Converts args to J1939 message suitable for RP1210_SendMessage function.
 
@@ -34,7 +34,7 @@ def toJ1939Message(pgn, priority, source, destination, data) -> bytes:
     ret_val += sanitize_msg_param(priority, 1)
     ret_val += sanitize_msg_param(source, 1)
     ret_val += sanitize_msg_param(destination, 1)
-    ret_val += sanitize_msg_param(data)
+    ret_val += sanitize_msg_param(data, data_size)
     return ret_val
 
 def toJ1939Request(pgn_requested, source, destination = 255, priority = 6) -> bytes:

--- a/RP1210/RP1210.py
+++ b/RP1210/RP1210.py
@@ -952,6 +952,8 @@ class RP1210API:
         """
         RxBuffer = create_string_buffer(BufferSize)
         size = self.ReadMessage(ClientID, RxBuffer, BufferSize, BlockOnRead)
+        if size <= 0:
+            return b''
         return RxBuffer[:size]
 
     def ReadVersion(self, DLLMajorVersionBuffer : bytes, 

--- a/RP1210/RP1210.py
+++ b/RP1210/RP1210.py
@@ -6,7 +6,7 @@ import configparser
 from configparser import ConfigParser
 from ctypes import POINTER, c_char_p, c_int32, c_long, c_short, c_void_p, cdll, CDLL, create_string_buffer
 from typing import Literal
-from RP1210 import Commands
+from RP1210 import Commands, sanitize_msg_param
 
 RP1210_ERRORS = {
     1: "NO_ERRORS",
@@ -1429,7 +1429,9 @@ class RP1210Client(RP1210VendorList):
         TODO: This function has not yet been rigorously tested.
         """
         try:
-            return self.getAPI().SendMessage(self.clientID, message, msg_size)
+            if msg_size == 0:
+                msg_size = len(message)
+            return self.getAPI().SendMessage(self.clientID, sanitize_msg_param(message, msg_size), msg_size)
         except Exception:
             return 128 # DLL_NOT_INITIALIZED
 

--- a/Test/test_1_j1939_diagnostics.py
+++ b/Test/test_1_j1939_diagnostics.py
@@ -246,3 +246,25 @@ def test_diagnosticmessage_conversion():
     assert not DiagnosticMessage()
     assert dm1
     assert int.from_bytes(J1939Message(timestamp + j1939_msg).getData(), 'big') == int(dm1)
+
+def test_diagnosticmessage_iterate():
+    pgn = 0xFECA
+    pri = 6
+    sa = 0x4E
+    da = 0xFF
+    timestamp = b'\x01\x02\x03\x04'
+    dm1 = DiagnosticMessage()
+    for i in range(20):
+        spn = i * 23
+        fmi = i
+        oc = 1 + i*3
+        dm1 += DTC(None, spn, fmi, oc)
+    count = 0
+    for dtc in dm1:
+        count += 1
+    assert count == 20
+    for i in range(20):
+        assert dm1[i].spn == i * 23
+        assert dm1[i].fmi == i
+        assert dm1[i].oc == 1 + i*3
+    

--- a/Test/test_2_nexiq.py
+++ b/Test/test_2_nexiq.py
@@ -224,7 +224,7 @@ def test_disconnected_rp1210client_commands():
     client.setVendor(API_NAME)
     assert client.getClientID() == 128
     clientID = client.connect()
-    assert clientID in RP1210.RP1210_ERRORS.keys()
+    assert clientID in RP1210.RP1210_ERRORS.keys() or 0 <= clientID <= 128
     assert clientID == client.getClientID()
     # sampling of simpler commands
     assert client.resetDevice() in RP1210.RP1210_ERRORS.keys()

--- a/Test/test_3_RP1210Client.py
+++ b/Test/test_3_RP1210Client.py
@@ -6,7 +6,7 @@ import time
 
 from RP1210.RP1210 import RP1210API
 
-TEST_ENABLED = True
+TEST_ENABLED = False
 SKIP_REASON = "Dual adapter tests are disabled."
 
 if not TEST_ENABLED:
@@ -16,8 +16,6 @@ def test_dual_adapters_begin():
     messagebox.showinfo("Connect your dual adapter setup!", 
                         "Connect your Noregon DLA2 and Nexiq USB-Link 2 together and power them up!")
 
-def test_RP1210API_tx_rx():
-    """Test RP1210API w/o using RP1210Client."""
 
 def test_dual_clients_tx_rx():
     nexiq = RP1210Client()

--- a/Test/test_3_RP1210Client.py
+++ b/Test/test_3_RP1210Client.py
@@ -1,0 +1,61 @@
+from ctypes import create_string_buffer
+from RP1210 import RP1210Client, J1939
+import pytest
+from tkinter import messagebox
+import time
+
+from RP1210.RP1210 import RP1210API
+
+TEST_ENABLED = True
+SKIP_REASON = "Dual adapter tests are disabled."
+
+if not TEST_ENABLED:
+    pytest.skip(SKIP_REASON, allow_module_level=True)
+
+def test_dual_adapters_begin():
+    messagebox.showinfo("Connect your dual adapter setup!", 
+                        "Connect your Noregon DLA2 and Nexiq USB-Link 2 together and power them up!")
+
+def test_RP1210API_tx_rx():
+    """Test RP1210API w/o using RP1210Client."""
+
+def test_dual_clients_tx_rx():
+    nexiq = RP1210Client()
+    dla2 = RP1210Client()
+    # set vendors and devices
+    nexiq.setVendor("NULN2R32")
+    nexiq.setDevice(1)
+    dla2.setVendor("DLAUSB32")
+    dla2.setDevice(100)
+    # connect to adapter
+    err_code = nexiq.connect(b"J1939:Baud=500")
+    assert 0 <= err_code <= 127
+    time.sleep(0.01)
+    err_code = dla2.connect(b"J1939:Baud=500")
+    assert 0 <= err_code <= 127
+    time.sleep(0.01)
+    # set all filters to pass
+    err_code = nexiq.setAllFiltersToPass()
+    assert 0 <= err_code <= 127
+    time.sleep(0.01)
+    err_code = dla2.setAllFiltersToPass()
+    assert 0 <= err_code <= 127
+
+    # send J1939 message
+    msg = J1939.toJ1939Message(0xFEDA, 6, 0x4E, 0xFF, 0xC0FFEE)
+    start_time = time.time()
+    assert nexiq.tx(msg) == 0
+    # receive J1939 message
+    msg_received = b''
+    while time.time() - start_time < 1 and msg_received == b'':
+        assert nexiq.tx(msg) == 0
+        time.sleep(0.001)
+        msg_received = dla2.rx()
+        time.sleep(0.001)
+    # disconnect adapters before asserts so as not to fill up client pool
+    assert nexiq.disconnect() == 0
+    assert dla2.disconnect() == 0
+    # check that msg was received and matches message that was sent
+    assert msg_received != b''
+    assert msg_received[4:] == msg
+


### PR DESCRIPTION
- Added data_size param to toJ1939Message()
- Fixed ReadDirect() not parsing RxBuffer correctly in many cases