### PR TITLE
Fix PDU1 PGNs

### DIFF
--- a/RP1210/J1939.py
+++ b/RP1210/J1939.py
@@ -236,12 +236,17 @@ class J1939Message():
         """Returns PGN (3 bytes) as int."""
         start = 4 + self.echo_offset
         end = 6 + self.echo_offset
-        return int.from_bytes(self.msg[start:end+1], 'little')
+        pgn = self.msg[start:(end+1)]
+        pgn_int = int.from_bytes(pgn, 'little')
+        # PDU1 (destination specific) - RP1210 adapters handle this in a dumb way
+        if pgn[1] < 0xF0 and pgn[0] == 0x00:
+            pgn_int += self.getDestination()
+        return pgn_int
 
     def getPriority(self) -> int:
         """Returns Priority (1 byte) as int."""
         loc = 7 + self.echo_offset
-        return int(self.msg[loc])
+        return int(self.msg[loc]) & 0b111
 
     def getSource(self) -> int:
         """Returns Source Address (1 byte) as int."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = RP1210
-version = 0.0.8
+version = 0.0.9
 keywords = RP1210, CAN, J1939
 author = Darius Fieschko
 author_email = dfieschko@gmail.com

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 setup(
   name = 'RP1210',
   packages = ['RP1210'],
-  version = '0.0.8',
+  version = '0.0.9',
   license='MIT',
   description = 'A Python32 implementation of the RP1210C standard.',
   long_description = open('README.md').read(),


### PR DESCRIPTION
RP1210 drivers remove DA from PGN in ReadMessage for J1939.  This is erroneous behavior and had to be corrected for in this package.