### PR TITLE
v0.0.10

### DIFF
--- a/RP1210/J1939.py
+++ b/RP1210/J1939.py
@@ -48,6 +48,7 @@ def toJ1939Request(pgn_requested, source, destination = 255, priority = 6) -> by
     - priority: priority of request; default is 6
     """
     pgn_request = sanitize_msg_param(pgn_requested, 3, 'little') # must be little-endian
+    pgn_request += b'\x00\x00\x00\x00\x00'
     return toJ1939Message(0x00EA00, priority, source, destination, pgn_request)
 
 class DTC():

--- a/RP1210/RP1210.py
+++ b/RP1210/RP1210.py
@@ -135,6 +135,8 @@ def translateErrorCode(ClientID :int) -> str:
         
         If there is no match, returns the clientID as str.
         """
+        if isinstance(ClientID, str): # if this got passed a string, return the string
+            return ClientID
         if 0 <= ClientID < 128:
             return "NO_ERRORS"
         if ClientID < 0: # some functions return negative value for error code

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = RP1210
-version = 0.0.9
+version = 0.0.10
 keywords = RP1210, CAN, J1939
 author = Darius Fieschko
 author_email = dfieschko@gmail.com

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 setup(
   name = 'RP1210',
   packages = ['RP1210'],
-  version = '0.0.9',
+  version = '0.0.10',
   license='MIT',
   description = 'A Python32 implementation of the RP1210C standard.',
   long_description = open('README.md').read(),


### PR DESCRIPTION
- Increase size of toJ1939Request data to 8 bytes
- Already-translated strings can be passed through translateErrorCode() unchanged
- Added band-aid to fix stalls/crashes with PCAN-RP1210 drivers