### PR TITLE
Update __driver_clientid_fix() for PCAN drivers

### DIFF
--- a/RP1210/RP1210.py
+++ b/RP1210/RP1210.py
@@ -1135,18 +1135,15 @@ class RP1210API:
         PCAN adapters also have an issue when trying to connect to adapters that aren't plugged in,
         so they get to join the hall of shame.
         """
-        if not self.__is_valid_clientid(clientID):
-            # cid = int(hex(clientID)[5:], 16) # snip off first 5 hex characters, translate back to int
-            cid = clientID & 0xFFFF
-            if self.__is_valid_clientid(cid):
-                clientID = cid
+        if clientID < 0: # some functions return negative value for error code
+            clientID *= -1
+        clientID &= 0xFFFF # Noregon can add garbage to leading bytes
+        if clientID > 0x8000:
+            clientID = 0xFFFF - clientID
         if self._api_name == "PEAKRP32" and clientID > 64:
             # PCAN drivers give invalid ClientID if it equals 114 (but cover wider range for safety) 
             clientID = 129  # ERR_INVALID_CLIENT_ID
         return clientID
-    
-    def __is_valid_clientid(self, clientID) -> bool:
-        return clientID in RP1210_ERRORS or (0 <= clientID < 128)
 
 class RP1210VendorList:
     """

--- a/Test/test_0_rp1210.py
+++ b/Test/test_0_rp1210.py
@@ -243,7 +243,7 @@ def test_driver_clientid_fix(input, expected):
     assert api.fix(input) == expected
 
 @pytest.mark.parametrize("input,expected",[
-    (114, 129), (0,0)
+    (114, 129), (0,0), (-0xFFFF, 0), (-0xFFFE, 1)
 ])
 def test_driver_clientid_fix_PEAKRP32(input, expected):
     """Tests _driver_clientid_fix function in RP1210API when using PEAKRP32 API."""

--- a/Test/test_0_rp1210.py
+++ b/Test/test_0_rp1210.py
@@ -225,3 +225,34 @@ def test_rp1210client_populate_logic():
         print(err)
         vendors = []
     assert vendors != []
+
+@pytest.mark.parametrize("input,expected",[
+    (0, 0), (1, 1), (2, 2), (-1, 1), (-2, 2), (128, 128), (-128, 128), (0x10FA3, 0x0FA3),
+    (-0x10FA3, 0x0FA3), (0xFFFF, 0), (0xFFFE, 1), (0xFFFD, 2), (-0xFFFD, 2), (-0xFFFFD, 2)
+])
+def test_driver_clientid_fix(input, expected):
+    """Tests _driver_clientid_fix function in RP1210API."""
+    class TestAPI(RP1210.RP1210API): # gotta make _driver_clientid_fix public
+        def __init__(self, api_name: str, WorkingAPIDirectory: str = None) -> None:
+            super().__init__(api_name, WorkingAPIDirectory)
+    
+        def fix(self, val : int):
+            return self._driver_clientid_fix(val)
+
+    api = TestAPI("test")
+    assert api.fix(input) == expected
+
+@pytest.mark.parametrize("input,expected",[
+    (114, 129), (0,0)
+])
+def test_driver_clientid_fix_PEAKRP32(input, expected):
+    """Tests _driver_clientid_fix function in RP1210API when using PEAKRP32 API."""
+    class TestAPI(RP1210.RP1210API):
+        def __init__(self, api_name: str, WorkingAPIDirectory: str = None) -> None:
+            super().__init__(api_name, WorkingAPIDirectory)
+    
+        def fix(self, val : int):
+            return self._driver_clientid_fix(val)
+
+    api = TestAPI("PEAKRP32")
+    assert api.fix(input) == expected

--- a/Test/test_genericVendor.py
+++ b/Test/test_genericVendor.py
@@ -141,16 +141,21 @@ def test_Devices(api_name : str):
         with pytest.raises(TypeError):
             assert device != "dingus"
 
-@pytest.mark.parametrize("api_name", argvalues=API_NAMES +INVALID_API_NAMES)
+@pytest.mark.parametrize("api_name", argvalues=API_NAMES + INVALID_API_NAMES)
 def test_Protocols(api_name : str):
     config = configparser.ConfigParser()
     utility = RP1210ConfigTestUtility(config)
     rp1210 = RP1210.RP1210Config(api_name, DLL_DIRECTORY, INI_DIRECTORY)
     config.read(INI_DIRECTORY + "\\" + api_name + ".ini")
     protocolIDs = rp1210.getProtocolIDs()
+    assert rp1210.getProtocol("test protocol name") is None
+    if not api_name in INVALID_API_NAMES:
+        assert protocolIDs
     for id in protocolIDs:
         protocol = rp1210.getProtocol(id)
         name = protocol.getString()
+        protocolFromString = rp1210.getProtocol(name)
+        assert protocolFromString.getString() == name
         assert name in rp1210.getProtocolNames()
         assert rp1210.getProtocol(name).getString() == name
         utility.verifyprotocoldata(protocol.getDescription, id, "ProtocolDescription")


### PR DESCRIPTION
- Updated `__driver_clientid_fix()` to include error checking from `translateErrorCode()`.

closes #66 