### PR TITLE
fix marshalling of setBlockTimeout data 

### DIFF
--- a/RP1210/RP1210.py
+++ b/RP1210/RP1210.py
@@ -1737,7 +1737,7 @@ class RP1210Client(RP1210VendorList):
         milliseconds. Set either block to 0 for infinite time.
         """
         cmd_num = 215
-        cmd_data = Commands.setJ1939Baud(block1, block2)
+        cmd_data = Commands.setBlockingTimeout(block1, block2)
         cmd_size = 2
         return self.command(cmd_num, cmd_data, cmd_size)
 


### PR DESCRIPTION
## 🐛 Bugs Fixed
from J13939Baud to BlockingTimeout command

## 👀 Checklist
- [ ✔️] Did you test your changes?
- [ !] Do the unit tests all pass? almost. test_disconnected_ClientConnect hangs on DGDPA5MA
- [ ✔️] Do the examples still work?
- [ ?] Are there any failing workflows?
- [✔️ ] Is `version` in `setup` up-to-date?


