### PR TITLE
Vendorlist properties

### DIFF
--- a/Examples/RP1210VendorList.py
+++ b/Examples/RP1210VendorList.py
@@ -10,8 +10,8 @@ for vendor in vendorList.getVendorList():
 print(f"API Object: {vendorList.getAPI()}")
 print(f"Number of vendors: {vendorList.numVendors()}")
 print(f"Number of devices: {vendorList.numDevices()}")
-# print(f"All vendor names: {vendorList.getVendorNames()}")
-# print(f"All API names: {vendorList.getAPINames()}")
+print(f"All vendor names: {vendorList.getVendorNames()}")
+print(f"All API names: {vendorList.getAPINames()}")
 
 # Connect to specific adapter
 vendorList.setVendor("NULN2R32")
@@ -35,7 +35,7 @@ if API_NAME in [str(i).split(' ')[0] for i in vendorList.getVendorList()]:
         f"Current vendor: {vendorList.getCurrentVendor()}, name: {vendorList.getVendorName()}, index: {vendorList.getVendorIndex()}")
     print(
         f"Vendor at index 2: {vendorList.getVendor(2)}, vendor index of DG121032: {vendorList.getVendorIndex('DG121032')}")
-    # print(f"All device IDs: {vendorList.getDeviceIDs()}")
+    print(f"All device IDs: {vendorList.getDeviceIDs()}")
 
     # check if the device is in the device list
     if DEVICE_ID in [str(i).split(' ')[0] for i in vendorList.getCurrentVendor().getDevices()]:

--- a/RP1210/RP1210.py
+++ b/RP1210/RP1210.py
@@ -5,7 +5,7 @@ import os
 import configparser
 from configparser import ConfigParser
 from ctypes import POINTER, c_char_p, c_int32, c_long, c_short, c_void_p, cdll, CDLL, create_string_buffer
-from typing import Literal, Type
+from typing import Literal
 from RP1210 import Commands, sanitize_msg_param
 
 RP1210_ERRORS = {
@@ -805,6 +805,9 @@ class RP1210API:
     def __str__(self):
         return self._api_name
 
+    def __eq__(self, other):
+        return str(self) == str(other)
+
     def getAPIName(self) -> str:
         """Returns API name for this API."""
         return self._api_name
@@ -1214,6 +1217,10 @@ class RP1210VendorList:
     @vendor.setter
     def vendor(self, vendor):
         self.setVendor(vendor)
+
+    @property
+    def api(self) -> RP1210API:
+        return self.getAPI()
 
     def __getitem__(self, index : int) -> RP1210Config:
         return self.vendors[index]

--- a/Test/test_0_rp1210.py
+++ b/Test/test_0_rp1210.py
@@ -5,7 +5,17 @@ from RP1210 import sanitize_msg_param
 import RP1210
 import pytest
 
-from Test.test_0_vendorlist import RP121032_PATH
+API_NAMES = ["PEAKRP32", "DLAUSB32", "DGDPA5MA", "NULN2R32",
+             "CMNSI632", "CIL7R32", "DrewLinQ", "DTKRP32"]
+INVALID_API_NAMES = ["empty_api", "invalid_api",
+                     "extra_empty_api", "invalid_pd_api"]
+
+# These tests are meant to be run with cwd @ repository's highest-level directory
+CWD = os.getcwd()
+TEST_FILES_DIRECTORY = CWD + ".\\Test\\test-files"
+INI_DIRECTORY = TEST_FILES_DIRECTORY + "\\ini-files"
+DLL_DIRECTORY = TEST_FILES_DIRECTORY + "\\dlls"
+RP121032_PATH = TEST_FILES_DIRECTORY + "\\RP121032.ini"
 
 def delete_file(path : str):
     if os.path.exists(path):

--- a/Test/test_0_rp1210.py
+++ b/Test/test_0_rp1210.py
@@ -268,3 +268,60 @@ def test_driver_clientid_fix_PEAKRP32(input, expected):
 
     api = TestAPI("PEAKRP32")
     assert api.fix(input) == expected
+
+def test_RP1210Client_magic_methods():
+    """Test __str__ and __int__  in RP1210Client."""
+    client = RP1210.RP1210Client(RP121032_PATH, DLL_DIRECTORY, INI_DIRECTORY)
+    for vendor in client:
+        client.setVendor(vendor)
+        assert str(client) == client.getCurrentVendor().getName()
+    assert int(client) == client.clientID
+
+def test_RP1210Protocol_magic_methods_arbitrary():
+    """Test __bool__ in RP1210Protocol"""
+    protocol = RP1210.RP1210Protocol({})
+    assert bool(protocol) == bool({})
+    protocol = RP1210.RP1210Protocol({'test':'1'})
+    assert bool(protocol) == bool({'test':'1'})
+
+def test_RP1210Device_magic_methods_arbitrary():
+    """Test __bool__ in RP1210Device"""
+    device = RP1210.RP1210Device({})
+    assert not device
+    assert "Invalid" in str(device)
+    assert int(device) == -1
+    device2 = RP1210.RP1210Device({'test':'1'})
+    assert not device2
+    assert "Invalid" in str(device2)
+    assert int(device2) == -1
+    assert device != device2
+
+def test_RP1210VendorList_setDeviceByDeviceID():
+    """Access `device` property in RP1210VendorList."""
+    vendors = RP1210.RP1210VendorList(RP121032_PATH, DLL_DIRECTORY, INI_DIRECTORY)
+    for vendor in vendors:
+        vendors.setVendor(vendor)
+        for deviceID in vendor.getDeviceIDs():
+            vendors.setDevice(deviceID)
+            assert vendors.device == vendors.getCurrentDevice()
+            vendors.device = deviceID
+            assert vendors.device == vendors.getCurrentDevice()
+        
+def test_RP1210VendorList_setDeviceByDevice():
+    vendors = RP1210.RP1210VendorList(RP121032_PATH, DLL_DIRECTORY, INI_DIRECTORY)
+    for vendor in vendors:
+        vendors.setVendor(vendor)
+        for deviceID in vendor.getDevices():
+            vendors.device = deviceID
+            assert vendors.device == vendors.getCurrentDevice()
+        for device in vendor.getDevices():
+            vendors.setDevice(device)
+            assert vendors.device == vendors.getCurrentDevice()
+
+def test_RP1210VendorList_setDevice_Error():
+    """Invalid cases of setDevice"""
+    vendors = RP1210.RP1210VendorList(RP121032_PATH, DLL_DIRECTORY, INI_DIRECTORY)
+    for vendor in vendors:
+        vendors.setVendor(vendor)
+        with pytest.raises(TypeError):
+            vendors.device = "dinglebop"

--- a/Test/test_0_vendorlist.py
+++ b/Test/test_0_vendorlist.py
@@ -260,3 +260,11 @@ def test_vendorlist_setVendor_newVendor():
     assert vendors.getAPIName() == api_name
     assert vendors.getVendorIndex() == vendors.getVendorIndex(api_name) != 0
     assert vendors.vendor == config
+
+def test_vendorlist_setVendor_fromList():
+    vendors = RP1210.RP1210VendorList(RP121032_PATH, DLL_DIRECTORY, INI_DIRECTORY)
+    length = len(vendors)
+    for vendor in vendors:
+        vendors.setVendor(vendor)
+        assert vendors.vendor == vendor
+        assert len(vendors) == length # make sure existing vendors aren't readded

--- a/Test/test_0_vendorlist.py
+++ b/Test/test_0_vendorlist.py
@@ -227,7 +227,7 @@ def test_vendorlist_array():
     """Treats vendor list as a list of RP1210Config objects."""
     vendors = RP1210.RP1210VendorList(RP121032_PATH, DLL_DIRECTORY, INI_DIRECTORY)
     for api_name in vendors.getAPINames():
-        assert api_name in getAPINames()
+        assert api_name in getAPINames(RP121032_PATH)
     assert len(vendors) == vendors.numVendors() == len(vendors.vendors)
     for vendor in vendors:
         assert vendor.getAPIName() in vendors.getAPINames()

--- a/Test/test_genericVendor.py
+++ b/Test/test_genericVendor.py
@@ -488,3 +488,16 @@ def test_RP1210VendorList_setVendorByVendor(api_name : str):
     assert vendors.getAPIName() == api_name
     assert vendors.getVendorIndex() == vendors.getVendorIndex(api_name)
     assert vendors.vendor == config
+
+@pytest.mark.parametrize("api_name", argvalues=API_NAMES)
+def test_RP1210VendorList_accessAPI(api_name : str):
+    """Access `api` property in RP1210VendorList."""
+    vendors = RP1210.RP1210VendorList(RP121032_PATH, DLL_DIRECTORY, INI_DIRECTORY)
+    dll_path = DLL_DIRECTORY + "\\" + api_name + ".dll"
+    api = RP1210.RP1210API(api_name, dll_path)
+    vendors.setVendor(api_name)
+    assert vendors.api == api == api_name
+    assert vendors.getAPIName() == vendors.api.getAPIName()
+    # setter should raise exception
+    with pytest.raises(AttributeError):
+        vendors.api = api

--- a/Test/test_genericVendor.py
+++ b/Test/test_genericVendor.py
@@ -423,10 +423,68 @@ def test_RP1210Config_magic_methods(api_name : str):
     ini_path = INI_DIRECTORY + "\\" + api_name + ".ini"
     dll_path = DLL_DIRECTORY + "\\" + api_name + ".dll"
     config = RP1210.RP1210Config(api_name, dll_path, ini_path)
+    config2 = RP1210.RP1210Config(api_name, dll_path, ini_path)
     assert bool(config) == config.isValid()
+    assert config == config2
+    if api_name != "NULN2R32":
+        assert config != RP1210.RP1210Config("NULN2R32", dll_path, ini_path)
 
 @pytest.mark.parametrize("api_name", argvalues=INVALID_API_NAMES)
 def test_RP1210Config_magic_methods_with_invalid_api(api_name : str):
     """Test __bool__ in RP1210Config with invalid API names."""
     config = RP1210.RP1210Config(api_name)
+    config2 = RP1210.RP1210Config(api_name)
     assert bool(config) == config.isValid()
+    assert config == config2
+    assert config != RP1210.RP1210Config("dinglebop")
+
+@pytest.mark.parametrize("api_name", argvalues=API_NAMES)
+def test_RP1210VendorList_addVendor(api_name : str):
+    """Tests addVendor function in RP1210VendorList"""
+    vendors = RP1210.RP1210VendorList(RP121032_PATH, DLL_DIRECTORY, INI_DIRECTORY)
+    ini_path = INI_DIRECTORY + "\\" + api_name + ".ini"
+    dll_path = DLL_DIRECTORY + "\\" + api_name + ".dll"
+    config = RP1210.RP1210Config(api_name, dll_path, ini_path)
+    assert config in vendors
+    assert RP1210.RP1210Config("dinglebop") not in vendors
+    # add by name
+    length = len(vendors)
+    vendors.addVendor(api_name)
+    assert len(vendors) == length + 1
+    assert vendors[length] == config
+    # add by RP1210Config object
+    vendors.addVendor(config)
+    assert len(vendors) == length + 2
+    assert vendors[length + 1] == config
+    # add random api name
+    vendors.addVendor("dinglebop")
+    assert len(vendors) == length + 3
+    assert vendors[length + 2] != config
+    assert not vendors[length + 2].isValid() # should be invalid
+    # add invalid type
+    with pytest.raises(TypeError):
+        vendors.addVendor(4)
+
+@pytest.mark.parametrize("api_name", argvalues=API_NAMES)
+def test_RP1210VendorList_setVendorByName(api_name : str):
+    """Tests setVendor function in RP1210VendorList"""
+    vendors = RP1210.RP1210VendorList(RP121032_PATH, DLL_DIRECTORY, INI_DIRECTORY)
+    ini_path = INI_DIRECTORY + "\\" + api_name + ".ini"
+    dll_path = DLL_DIRECTORY + "\\" + api_name + ".dll"
+    config = RP1210.RP1210Config(api_name, dll_path, ini_path)
+    vendors.setVendor(api_name)
+    assert vendors.getAPIName() == api_name
+    assert vendors.getVendorIndex() == vendors.getVendorIndex(api_name)
+    assert vendors.vendor == config
+
+@pytest.mark.parametrize("api_name", argvalues=API_NAMES)
+def test_RP1210VendorList_setVendorByVendor(api_name : str):
+    """Tests setVendor function in RP1210VendorList"""
+    vendors = RP1210.RP1210VendorList(RP121032_PATH, DLL_DIRECTORY, INI_DIRECTORY)
+    ini_path = INI_DIRECTORY + "\\" + api_name + ".ini"
+    dll_path = DLL_DIRECTORY + "\\" + api_name + ".dll"
+    config = RP1210.RP1210Config(api_name, dll_path, ini_path)
+    vendors.setVendor(config)
+    assert vendors.getAPIName() == api_name
+    assert vendors.getVendorIndex() == vendors.getVendorIndex(api_name)
+    assert vendors.vendor == config

--- a/Test/test_genericVendor.py
+++ b/Test/test_genericVendor.py
@@ -391,30 +391,6 @@ def test_RP1210API_magic_methods_with_invalid_api(api_name : str):
     assert bool(api) == api.isValid()
     assert str(api) == api.getAPIName()
 
-def test_RP1210Client_magic_methods():
-    """Test __str__ and __int__  in RP1210Client."""
-    client = RP1210.RP1210Client(RP121032_PATH, DLL_DIRECTORY, INI_DIRECTORY)
-    if client.getCurrentVendor():
-        assert str(client) == client.getCurrentVendor().getName()
-    else:
-        # has not assigned vendor, vendor=""
-        assert str(client) == ""
-    assert int(client) == client.clientID
-
-def test_RP1210Protocol_magic_methods_arbitrary():
-    """Test __bool__ in RP1210Protocol"""
-    protocol = RP1210.RP1210Protocol({})
-    assert bool(protocol) == bool({})
-    protocol = RP1210.RP1210Protocol({'test':'1'})
-    assert bool(protocol) == bool({'test':'1'})
-
-def test_RP1210Device_magic_methods_arbitrary():
-    """Test __bool__ in RP1210Device"""
-    device = RP1210.RP1210Device({})
-    assert bool(device) == bool({})
-    device = RP1210.RP1210Device({'test':'1'})
-    assert bool(device) == bool({'test':'1'})
-
 @pytest.mark.parametrize("api_name", argvalues=API_NAMES)
 def test_RP1210Config_magic_methods(api_name : str):
     """Test __bool__ in RP1210Config."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = RP1210
-version = 0.0.15
+version = 0.0.16
 keywords = RP1210, CAN, J1939
 author = Darius Fieschko
 author_email = dfieschko@gmail.com

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 setup(
   name = 'RP1210',
   packages = ['RP1210'],
-  version = '0.0.15',
+  version = '0.0.16',
   license='MIT',
   description = 'A Python32 implementation of the RP1210C standard.',
   long_description = open('README.md').read(),


### PR DESCRIPTION
## ✨ Enhancements
- Added `vendor` property to RP1210VendorList
- Added `api` property to RP1210VendorList
- Added `device` property to RP1210VendorList
- Added `addVendor()` function to RP1210VendorList
- Added `getAPIName()` function to RP1210VendorList
- `setVendor()` in RP1210VendorList now can take `RP1210Config` objects as argument
   - Will add new vendor to list if it doesn't already exist in the list.
- `setDevice()` in RP1210VendorList now can take `RP1210Device` objects as argument
- Added `__int__()` to RP1210Device (returns deviceID)
- Uncommented function calls in RP1210VendorList.py to test newly added functions getVendorNames(), getAPINames(), getDeviceIDs()

## 🗿 Miscellaneous
- Moved magic methods to top of class for a couple classes in RP1210.py
- More complete tests for RP1210Device and RP1210VendorList (didn't really affect coverage)

## ✔️ Closed Issues
closes #68, closes #86

## 👀 Checklist
- [x] Did you test your changes?
- [x] Do the unit tests all pass?
- [x] Do the examples still work?
- [x] Are there any failing workflows?
- [x] Is `version` in `setup` up-to-date?
