### PR TITLE
Add float case to sanitize_msg_param()

### DIFF
--- a/RP1210/__init__.py
+++ b/RP1210/__init__.py
@@ -45,6 +45,9 @@ def sanitize_msg_param(param, num_bytes : int = 0, byteorder : str = 'big') -> b
             param2 = param
         val = int.from_bytes(param2[:num_bytes], byteorder)
         return sanitize_msg_param(val, num_bytes, byteorder)
+    elif isinstance(param, float):
+        # convert to int, run sanitize_msg_param again
+        return sanitize_msg_param(int(param), num_bytes, byteorder)
     else:
         try:
             return sanitize_msg_param(bytes(param), num_bytes, byteorder)

--- a/Test/test_0_rp1210.py
+++ b/Test/test_0_rp1210.py
@@ -213,6 +213,9 @@ def test_sanitize_msg_param_bool():
     assert sanitize_msg_param(True) == b'\x01'
     assert sanitize_msg_param(False) == b'\x00'
 
+def test_sanitize_msg_param_float():
+    assert sanitize_msg_param(0.34) == b'\x00'
+
 def test_sanitize_msg_param_typeerror():
     with pytest.raises(TypeError):
         sanitize_msg_param(RP1210.RP1210VendorList())

--- a/Test/test_1_j1939.py
+++ b/Test/test_1_j1939.py
@@ -537,7 +537,7 @@ def test_generateNetMgmtName(aac, ig, vsi, vs, func, func_inst, ecu_inst, mc, id
 def test_generateNetMgmtName_invalid_input():
     """Test generateNetMgmtName() function with invalid inputs"""
     # a list of different data types
-    invalid_type = [0.1]
+    invalid_type = [J1939.generateNetMgmtName] # feed it a function pointer, that's definitely wrong
     # a dictionary of each field and out-of-range int/bytes
     invalid_range={
         'aac': [2, b'\xff'],

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = RP1210
-version = 0.0.17
+version = 0.0.18
 keywords = RP1210, CAN, J1939
 author = Darius Fieschko
 author_email = dfieschko@gmail.com

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 setup(
   name = 'RP1210',
   packages = ['RP1210'],
-  version = '0.0.17',
+  version = '0.0.18',
   license='MIT',
   description = 'A Python32 implementation of the RP1210C standard.',
   long_description = open('README.md').read(),


### PR DESCRIPTION
## ✨ Enhancements
- Added a check for `float` inputs to sanitize_msg_param()
   - Will convert the value to an int and return bytes based on that

## 👀 Checklist
- [x] Did you test your changes?
- [x] Do the unit tests all pass?
- [ ] Do the examples still work?
- [x] Are there any failing workflows?
- [x] Is `version` in `setup` up-to-date?
