### PR TITLE
Fixing RequestDownload and RequestUpload

### DIFF
--- a/RP1210/UDS/RequestDownload.py
+++ b/RP1210/UDS/RequestDownload.py
@@ -66,8 +66,8 @@ class RequestDownloadRequest(UDSMessage):
     @maddr.setter
     def maddr(self, maddr: Union[int, bytes]) -> None:
         maddr = sanitize_msg_param(maddr)
-        if(self._autoALFID): # Auto-calculating alfid
-            if(len(maddr) > 0x0f):
+        if self._autoALFID: # Auto-calculating alfid
+            if len(maddr) > 0x0f:
                 raise ValueError(F"maddr length must be less than 16 bytes, got {len(maddr)} bytes: {maddr}")
             self.alfid = (self.alfid & 0xf0) | (len(maddr) & 0x0f)
         self._maddr = maddr
@@ -79,8 +79,8 @@ class RequestDownloadRequest(UDSMessage):
     @msize.setter
     def msize(self, msize: Union[int, bytes]) -> None:
         msize = sanitize_msg_param(msize)
-        if(self._autoALFID): # Auto-calculating alfid
-            if(len(msize) > 0x0f):
+        if self._autoALFID: # Auto-calculating alfid
+            if len(msize) > 0x0f:
                 raise ValueError(F"msize length must be less than 16 bytes, got {len(msize)} bytes: {msize}")
             self.alfid = (self.alfid & 0x0f) | ((len(msize) & 0x0f) << 4)
         self._msize = msize

--- a/RP1210/UDS/RequestDownload.py
+++ b/RP1210/UDS/RequestDownload.py
@@ -2,9 +2,6 @@ from typing import Union
 from . import UDSMessage
 from .. import sanitize_msg_param
 
-from RP1210 import sanitize_msg_param
-from RP1210.UDS import UDSMessage
-
 class RequestDownloadRequest(UDSMessage):
     """
     Request Download (Request)

--- a/RP1210/UDS/RequestDownload.py
+++ b/RP1210/UDS/RequestDownload.py
@@ -66,10 +66,10 @@ class RequestDownloadRequest(UDSMessage):
     @maddr.setter
     def maddr(self, maddr: Union[int, bytes]) -> None:
         maddr = sanitize_msg_param(maddr)
-        if(self._autoALFID == True): # Auto-calculating alfid
-            if(maddr.__len__() > 0x0f):
-                raise ValueError(F"maddr length must be less than 16 bytes, got {maddr.__len__()} bytes: {maddr}")
-            self.alfid = (self.alfid & 0xf0) | (maddr.__len__() & 0x0f)
+        if(self._autoALFID): # Auto-calculating alfid
+            if(len(maddr) > 0x0f):
+                raise ValueError(F"maddr length must be less than 16 bytes, got {len(maddr)} bytes: {maddr}")
+            self.alfid = (self.alfid & 0xf0) | (len(maddr) & 0x0f)
         self._maddr = maddr
 
     @property
@@ -79,10 +79,10 @@ class RequestDownloadRequest(UDSMessage):
     @msize.setter
     def msize(self, msize: Union[int, bytes]) -> None:
         msize = sanitize_msg_param(msize)
-        if(self._autoALFID == True): # Auto-calculating alfid
-            if(msize.__len__() > 0x0f):
-                raise ValueError(F"msize length must be less than 16 bytes, got {msize.__len__()} bytes: {msize}")
-            self.alfid = (self.alfid & 0x0f) | ((msize.__len__() & 0x0f) << 4)
+        if(self._autoALFID): # Auto-calculating alfid
+            if(len(msize) > 0x0f):
+                raise ValueError(F"msize length must be less than 16 bytes, got {len(msize)} bytes: {msize}")
+            self.alfid = (self.alfid & 0x0f) | ((len(msize) & 0x0f) << 4)
         self._msize = msize
     
     @property

--- a/RP1210/UDS/RequestDownload.py
+++ b/RP1210/UDS/RequestDownload.py
@@ -1,20 +1,23 @@
 from . import UDSMessage
 from .. import sanitize_msg_param
 
+from RP1210 import sanitize_msg_param
+from RP1210.UDS import UDSMessage
 
 class RequestDownloadRequest(UDSMessage):
     """
     Request Download (Request)
     - `sid` = 0x34
-    - `did` = dfid + alfid
+    - `data` = dfid + alfid + maddr + msize
         - `dfid' = dataFormatIdentifier (1 byte)
         - `alfid' = addressAndLengthFormateIdentifier (1 byte)
             - bit 7 - 4: define length (number of bytes) of memoryAddress
             - bit 3 - 0`: define length (number of bytes) of memorySize
-    - `data` = maddr + msize
         - `maddr` = memoryAddress (n bytes)
         - `msize` = memorySize (n bytes)
     """
+
+    _DFID_IDX = 0
 
     _sid = 0x34
     _isResponse = False
@@ -22,13 +25,65 @@ class RequestDownloadRequest(UDSMessage):
     def __init__(self, dfid: bytes = b'', alfid: bytes = b'', maddr: bytes = b'', msize: bytes = b''):
         super().__init__()
         self._hasSubfn = False
-        self._hasDID = True
+        self._hasDID = False
         self._hasData = True
         self._dataSize = len(maddr + msize)
         self._dataSizeCanChange = True
 
-        self.did = int.from_bytes(sanitize_msg_param(dfid + alfid, 2), 'big')
-        self.data = maddr + msize
+        self.dfid = dfid
+        self.alfid = alfid
+        self.maddr = maddr
+        self.msize = msize
+
+        # self.did = int.from_bytes(sanitize_msg_param(dfid + alfid, 2), 'big') # remove later
+        # self.data = dfid + alfid + maddr + msize
+
+    @property
+    def dfid(self) -> int:
+        return int.from_bytes(self._dfid, 'big')
+
+    @dfid.setter
+    def dfid(self, dfid: int | bytes):
+        dfid = sanitize_msg_param(dfid)
+        if(dfid.__len__() != 1):
+            raise ValueError(F"DFID length must be 1 byte, got {dfid.__len__()} bytes: {dfid}")
+        self._dfid = dfid
+    
+    @property
+    def alfid(self) -> int:
+        return int.from_bytes(self._alfid, 'big')
+
+    @alfid.setter
+    def alfid(self, alfid: int | bytes):
+        alfid = sanitize_msg_param(alfid)
+        if(alfid.__len__() != 1):
+            raise ValueError(F"ALFID length must be 1 byte, got {alfid.__len__()} bytes: {alfid}")
+        self._alfid = alfid
+
+    @property
+    def maddr(self) -> int:
+        return int.from_bytes(self._maddr, 'big')
+
+    @maddr.setter
+    def maddr(self, maddr: int | bytes):
+        maddr = sanitize_msg_param(maddr)
+        if(maddr.__len__() != 1):
+            raise ValueError(F"maddr length must be 1 byte, got {maddr.__len__()} bytes: {maddr}")
+        self._maddr = maddr
+    
+    @property
+    def msize(self) -> int:
+        return int.from_bytes(self._msize, 'big')
+
+    @msize.setter
+    def msize(self, msize: int | bytes):
+        msize = sanitize_msg_param(msize)
+        if(msize.__len__() != 1):
+            raise ValueError(F"msize length must be 1 byte, got {msize.__len__()} bytes: {msize}")
+        self._msize = msize
+    
+    def _refresh_data(self) -> None:
+        self.data = sanitize_msg_param(self._dfid) + sanitize_msg_param(self._alfid)
 
 
 class RequestDownloadResponse(UDSMessage):
@@ -47,7 +102,7 @@ class RequestDownloadResponse(UDSMessage):
     def __init__(self, did: int = 0, data: bytes = b''):
         super().__init__()
         self._hasSubfn = False
-        self._hasDID = True
+        self._hasDID = False
         self._hasData = True
         self._dataSize = len(data)
         self._dataSizeCanChange = True

--- a/RP1210/UDS/RequestDownload.py
+++ b/RP1210/UDS/RequestDownload.py
@@ -10,9 +10,9 @@ class RequestDownloadRequest(UDSMessage):
     - `sid` = 0x34
     - `data` = dfid + alfid + maddr + msize
         - `dfid' = dataFormatIdentifier (1 byte)
-        - `alfid' = addressAndLengthFormateIdentifier (1 byte)
-            - bit 7 - 4: define length (number of bytes) of memoryAddress
-            - bit 3 - 0`: define length (number of bytes) of memorySize
+        - `alfid' = addressAndLengthFormatIdentifier (1 byte)
+            - bits 7-4: define length (number of bytes) of memorySize
+            - bits 3-0`: define length (number of bytes) of memoryAddress
         - `maddr` = memoryAddress (n bytes)
         - `msize` = memorySize (n bytes)
     """
@@ -21,65 +21,67 @@ class RequestDownloadRequest(UDSMessage):
     _isResponse = False
 
     def __init__(self, dfid: bytes = b'\x00', alfid: bytes = b'\x00', maddr: bytes = b'', msize: bytes = b'', autoALFID: bool = True):
+        """
+        - `dfid`: Data Format Identifier (1 byte). Default is `0x00` (no encryption or compression), other values are manufacturer-specific.
+        - `alfid`: Address and Length Format Identifer (1 byte). Can be left default if `autoALFID` is `True`.
+            - bits 7-4: define length (number of bytes) of msize
+            - bits 3-0: define length (number of bytes) of maddr
+        - `maddr`: memoryAddress (0-15 bytes)
+        - `msize`: memorySize (0-15 bytes)
+        - `autoALFID`: If `True`, `alfid` is automatically calculated based on the values of `maddr` and `msize`. If `False`, `alfid` must
+        be specified manually to produce a valid request.
+        """
         super().__init__()
-        self._hasSubfn = False
-        self._hasDID = False
-        self._hasData = True
-        self._dataSizeCanChange = True
+        self._hasSubfn:          bool = False
+        self._hasDID:            bool = False
+        self._hasData:           bool = True
+        self._dataSizeCanChange: bool = True
+
         self._autoALFID: bool = autoALFID
+        self.dfid             = dfid
+        self.alfid            = alfid
+        self.maddr            = maddr
+        self.msize            = msize
 
-        self.dfid = dfid
-        self.alfid = alfid
-        self.maddr = maddr
-        self.msize = msize
-        self._dataSize = len(self.data)
-
-        # self.did = int.from_bytes(sanitize_msg_param(dfid + alfid, 2), 'big') # remove later
-        # self.data = dfid + alfid + maddr + msize
+        self._dataSize: int = len(self.data)
 
     @property
     def dfid(self) -> int:
         return int.from_bytes(self._dfid, 'big')
 
     @dfid.setter
-    def dfid(self, dfid: int | bytes):
-        dfid = sanitize_msg_param(dfid, 1)
-        # if(dfid.__len__() != 1):
-        #     raise ValueError(F"DFID length must be 1 byte, got {dfid.__len__()} bytes: {dfid}")
-        self._dfid = dfid
+    def dfid(self, dfid: int | bytes) -> None:
+        self._dfid = sanitize_msg_param(dfid, 1)
     
     @property
     def alfid(self) -> int:
         return int.from_bytes(self._alfid, 'big')
 
     @alfid.setter
-    def alfid(self, alfid: int | bytes):
-        alfid = sanitize_msg_param(alfid, 1)
-        # if(alfid.__len__() != 1):
-        #     raise ValueError(F"ALFID length must be 1 byte, got {alfid.__len__()} bytes: {alfid}")
-        self._alfid = alfid
+    def alfid(self, alfid: int | bytes) -> None:
+        self._alfid = sanitize_msg_param(alfid, 1)
 
     @property
     def maddr(self) -> int:
         return int.from_bytes(self._maddr, 'big')
 
     @maddr.setter
-    def maddr(self, maddr: int | bytes):
+    def maddr(self, maddr: int | bytes) -> None:
         maddr = sanitize_msg_param(maddr)
-        if(self._autoALFID == True):
+        if(self._autoALFID == True): # Auto-calculating alfid
             if(maddr.__len__() > 0x0f):
                 raise ValueError(F"maddr length must be less than 16 bytes, got {maddr.__len__()} bytes: {maddr}")
             self.alfid = (self.alfid & 0xf0) | (maddr.__len__() & 0x0f)
         self._maddr = maddr
-    
+
     @property
     def msize(self) -> int:
         return int.from_bytes(self._msize, 'big')
 
     @msize.setter
-    def msize(self, msize: int | bytes):
+    def msize(self, msize: int | bytes) -> None:
         msize = sanitize_msg_param(msize)
-        if(self._autoALFID == True):
+        if(self._autoALFID == True): # Auto-calculating alfid
             if(msize.__len__() > 0x0f):
                 raise ValueError(F"msize length must be less than 16 bytes, got {msize.__len__()} bytes: {msize}")
             self.alfid = (self.alfid & 0x0f) | ((msize.__len__() & 0x0f) << 4)
@@ -87,11 +89,10 @@ class RequestDownloadRequest(UDSMessage):
     
     @property
     def data(self) -> bytes:
+        """
+        Concatenates the request's properties to form the data field.
+        """
         return sanitize_msg_param(self._dfid) + sanitize_msg_param(self._alfid) + sanitize_msg_param(self._maddr) + sanitize_msg_param(self._msize)
-
-    # @property
-    # def _dataSize(self) -> int:
-    #     return self.data.__len__()
 
 
 class RequestDownloadResponse(UDSMessage):

--- a/RP1210/UDS/RequestDownload.py
+++ b/RP1210/UDS/RequestDownload.py
@@ -1,3 +1,4 @@
+from typing import Union
 from . import UDSMessage
 from .. import sanitize_msg_param
 
@@ -50,7 +51,7 @@ class RequestDownloadRequest(UDSMessage):
         return int.from_bytes(self._dfid, 'big')
 
     @dfid.setter
-    def dfid(self, dfid: int | bytes) -> None:
+    def dfid(self, dfid: Union[int, bytes]) -> None:
         self._dfid = sanitize_msg_param(dfid, 1)
     
     @property
@@ -58,7 +59,7 @@ class RequestDownloadRequest(UDSMessage):
         return int.from_bytes(self._alfid, 'big')
 
     @alfid.setter
-    def alfid(self, alfid: int | bytes) -> None:
+    def alfid(self, alfid: Union[int, bytes]) -> None:
         self._alfid = sanitize_msg_param(alfid, 1)
 
     @property
@@ -66,7 +67,7 @@ class RequestDownloadRequest(UDSMessage):
         return int.from_bytes(self._maddr, 'big')
 
     @maddr.setter
-    def maddr(self, maddr: int | bytes) -> None:
+    def maddr(self, maddr: Union[int, bytes]) -> None:
         maddr = sanitize_msg_param(maddr)
         if(self._autoALFID == True): # Auto-calculating alfid
             if(maddr.__len__() > 0x0f):
@@ -79,7 +80,7 @@ class RequestDownloadRequest(UDSMessage):
         return int.from_bytes(self._msize, 'big')
 
     @msize.setter
-    def msize(self, msize: int | bytes) -> None:
+    def msize(self, msize: Union[int, bytes]) -> None:
         msize = sanitize_msg_param(msize)
         if(self._autoALFID == True): # Auto-calculating alfid
             if(msize.__len__() > 0x0f):
@@ -127,7 +128,7 @@ class RequestDownloadResponse(UDSMessage):
         return self.data[0]
 
     @lfid.setter
-    def lfid(self, lfid: int | bytes) -> None:
+    def lfid(self, lfid: Union[int, bytes]) -> None:
         self.data = sanitize_msg_param(lfid, 1) + self.data[1:]
 
     @property
@@ -138,5 +139,5 @@ class RequestDownloadResponse(UDSMessage):
         return int.from_bytes(self.data[1:], 'big')
 
     @mnrob.setter
-    def mnrob(self, mnrob: int | bytes) -> None:
+    def mnrob(self, mnrob: Union[int, bytes]) -> None:
         self.data = sanitize_msg_param(self.data[0]) + sanitize_msg_param(mnrob)

--- a/RP1210/UDS/RequestUpload.py
+++ b/RP1210/UDS/RequestUpload.py
@@ -2,7 +2,6 @@ from typing import Union
 from . import UDSMessage
 from .. import sanitize_msg_param
 
-
 class RequestUploadRequest(UDSMessage):
     """
     Request Upload (Request)
@@ -67,10 +66,10 @@ class RequestUploadRequest(UDSMessage):
     @maddr.setter
     def maddr(self, maddr: Union[int, bytes]) -> None:
         maddr = sanitize_msg_param(maddr)
-        if(self._autoALFID == True): # Auto-calculating alfid
-            if(maddr.__len__() > 0x0f):
-                raise ValueError(F"maddr length must be less than 16 bytes, got {maddr.__len__()} bytes: {maddr}")
-            self.alfid = (self.alfid & 0xf0) | (maddr.__len__() & 0x0f)
+        if(self._autoALFID): # Auto-calculating alfid
+            if(len(maddr) > 0x0f):
+                raise ValueError(F"maddr length must be less than 16 bytes, got {len(maddr)} bytes: {maddr}")
+            self.alfid = (self.alfid & 0xf0) | (len(maddr) & 0x0f)
         self._maddr = maddr
 
     @property
@@ -80,12 +79,12 @@ class RequestUploadRequest(UDSMessage):
     @msize.setter
     def msize(self, msize: Union[int, bytes]) -> None:
         msize = sanitize_msg_param(msize)
-        if(self._autoALFID == True): # Auto-calculating alfid
-            if(msize.__len__() > 0x0f):
-                raise ValueError(F"msize length must be less than 16 bytes, got {msize.__len__()} bytes: {msize}")
-            self.alfid = (self.alfid & 0x0f) | ((msize.__len__() & 0x0f) << 4)
+        if(self._autoALFID): # Auto-calculating alfid
+            if(len(msize) > 0x0f):
+                raise ValueError(F"msize length must be less than 16 bytes, got {len(msize)} bytes: {msize}")
+            self.alfid = (self.alfid & 0x0f) | ((len(msize) & 0x0f) << 4)
         self._msize = msize
-    
+
     @property
     def data(self) -> bytes:
         """

--- a/RP1210/UDS/RequestUpload.py
+++ b/RP1210/UDS/RequestUpload.py
@@ -66,8 +66,8 @@ class RequestUploadRequest(UDSMessage):
     @maddr.setter
     def maddr(self, maddr: Union[int, bytes]) -> None:
         maddr = sanitize_msg_param(maddr)
-        if(self._autoALFID): # Auto-calculating alfid
-            if(len(maddr) > 0x0f):
+        if self._autoALFID: # Auto-calculating alfid
+            if len(maddr) > 0x0f:
                 raise ValueError(F"maddr length must be less than 16 bytes, got {len(maddr)} bytes: {maddr}")
             self.alfid = (self.alfid & 0xf0) | (len(maddr) & 0x0f)
         self._maddr = maddr
@@ -79,8 +79,8 @@ class RequestUploadRequest(UDSMessage):
     @msize.setter
     def msize(self, msize: Union[int, bytes]) -> None:
         msize = sanitize_msg_param(msize)
-        if(self._autoALFID): # Auto-calculating alfid
-            if(len(msize) > 0x0f):
+        if self._autoALFID: # Auto-calculating alfid
+            if len(msize) > 0x0f:
                 raise ValueError(F"msize length must be less than 16 bytes, got {len(msize)} bytes: {msize}")
             self.alfid = (self.alfid & 0x0f) | ((len(msize) & 0x0f) << 4)
         self._msize = msize

--- a/RP1210/UDS/RequestUpload.py
+++ b/RP1210/UDS/RequestUpload.py
@@ -1,3 +1,4 @@
+from typing import Union
 from . import UDSMessage
 from .. import sanitize_msg_param
 
@@ -48,7 +49,7 @@ class RequestUploadRequest(UDSMessage):
         return int.from_bytes(self._dfid, 'big')
 
     @dfid.setter
-    def dfid(self, dfid: int | bytes) -> None:
+    def dfid(self, dfid: Union[int, bytes]) -> None:
         self._dfid = sanitize_msg_param(dfid, 1)
     
     @property
@@ -56,7 +57,7 @@ class RequestUploadRequest(UDSMessage):
         return int.from_bytes(self._alfid, 'big')
 
     @alfid.setter
-    def alfid(self, alfid: int | bytes) -> None:
+    def alfid(self, alfid: Union[int, bytes]) -> None:
         self._alfid = sanitize_msg_param(alfid, 1)
 
     @property
@@ -64,7 +65,7 @@ class RequestUploadRequest(UDSMessage):
         return int.from_bytes(self._maddr, 'big')
 
     @maddr.setter
-    def maddr(self, maddr: int | bytes) -> None:
+    def maddr(self, maddr: Union[int, bytes]) -> None:
         maddr = sanitize_msg_param(maddr)
         if(self._autoALFID == True): # Auto-calculating alfid
             if(maddr.__len__() > 0x0f):
@@ -77,7 +78,7 @@ class RequestUploadRequest(UDSMessage):
         return int.from_bytes(self._msize, 'big')
 
     @msize.setter
-    def msize(self, msize: int | bytes) -> None:
+    def msize(self, msize: Union[int, bytes]) -> None:
         msize = sanitize_msg_param(msize)
         if(self._autoALFID == True): # Auto-calculating alfid
             if(msize.__len__() > 0x0f):
@@ -125,7 +126,7 @@ class RequestUploadResponse(UDSMessage):
         return self.data[0]
 
     @lfid.setter
-    def lfid(self, lfid: int | bytes) -> None:
+    def lfid(self, lfid: Union[int, bytes]) -> None:
         self.data = sanitize_msg_param(lfid, 1) + self.data[1:]
 
     @property
@@ -136,5 +137,5 @@ class RequestUploadResponse(UDSMessage):
         return int.from_bytes(self.data[1:], 'big')
 
     @mnrob.setter
-    def mnrob(self, mnrob: int | bytes) -> None:
+    def mnrob(self, mnrob: Union[int, bytes]) -> None:
         self.data = sanitize_msg_param(self.data[0]) + sanitize_msg_param(mnrob)

--- a/RP1210/UDS/RequestUpload.py
+++ b/RP1210/UDS/RequestUpload.py
@@ -29,32 +29,44 @@ class RequestUploadResponse(UDSMessage):
     """
     Request Upload (Response)
     - `sid` = 0x75
-    - `did` = lengthFormatIdentifier (1 byte)
-    - `data` = maxNumberOfBlockLength
+    - `data` = lfid + mnrob
+        - `lfid` = lengthFormatIdentifier (1 byte)
+            - bit 7 - 4: maxNumberOfBlockLength
+            - bit 3 - 0: reserved; set to be 0
+        - `mnrob` = maxNumberOfBlockLength (n bytes)
     """
 
     _sid = 0x75
     _isResponse = True
 
-    def __init__(self, did: int = 0, data: bytes = b''):
+    def __init__(self, data: bytes = b''):
         super().__init__()
         self._hasSubfn = False
-        self._hasDID = True
+        self._hasDID = False
         self._hasData = True
         self._dataSize = len(data)
         self._dataSizeCanChange = True
 
-        self.did = did
         self.data = data
 
     @property
-    def did(self) -> int:
-        return self._did
+    def lfid(self) -> int:
+        """
+        Length format identifier. Only bits 7-4 are used.
+        """
+        return self.data[0]
 
-    @did.setter
-    def did(self, val: int):
+    @lfid.setter
+    def lfid(self, lfid: int | bytes) -> None:
+        self.data = sanitize_msg_param(lfid, 1) + self.data[1:]
+
+    @property
+    def mnrob(self) -> int:
         """
-        DID is 1 byte
+        Max NumbeR Of Blocks. Length must match the value specified in the LFID.
         """
-        val = int.from_bytes(sanitize_msg_param(val, 1), 'big')
-        self._did = val & 0xFF
+        return int.from_bytes(self.data[1:], 'big')
+
+    @mnrob.setter
+    def mnrob(self, mnrob: int | bytes) -> None:
+        self.data = sanitize_msg_param(self.data[0]) + sanitize_msg_param(mnrob)

--- a/RP1210/UDS/RequestUpload.py
+++ b/RP1210/UDS/RequestUpload.py
@@ -6,23 +6,91 @@ class RequestUploadRequest(UDSMessage):
     """
     Request Upload (Request)
     - `sid` = 0x35
-    - `did` = dataFormatIdentifier (1 byte) + addressAndLengthFormatIdentifier (1 byte)
-    - `data` = memoryAddress + memorySize
+    - `data` = dfid + alfid + maddr + msize
+        - `dfid' = dataFormatIdentifier (1 byte)
+        - `alfid' = addressAndLengthFormatIdentifier (1 byte)
+            - bits 7-4: define length (number of bytes) of memorySize
+            - bits 3-0`: define length (number of bytes) of memoryAddress
+        - `maddr` = memoryAddress (n bytes)
+        - `msize` = memorySize (n bytes)
     """
 
     _sid = 0x35
     _isResponse = False
 
-    def __init__(self, did: int = 0, data: bytes = b''):
+    def __init__(self, dfid: bytes = b'\x00', alfid: bytes = b'\x00', maddr: bytes = b'', msize: bytes = b'', autoALFID: bool = True):
+        """
+        - `dfid`: Data Format Identifier (1 byte). Default is `0x00` (no encryption or compression), other values are manufacturer-specific.
+        - `alfid`: Address and Length Format Identifer (1 byte). Can be left default if `autoALFID` is `True`.
+            - bits 7-4: define length (number of bytes) of msize
+            - bits 3-0: define length (number of bytes) of maddr
+        - `maddr`: memoryAddress (0-15 bytes)
+        - `msize`: memorySize (0-15 bytes)
+        - `autoALFID`: If `True`, `alfid` is automatically calculated based on the values of `maddr` and `msize`. If `False`, `alfid` must
+        be specified manually to produce a valid request.
+        """
         super().__init__()
-        self._hasSubfn = False
-        self._hasDID = True
-        self._hasData = True
-        self._dataSize = len(data)
-        self._dataSizeCanChange = True
+        self._hasSubfn:          bool = False
+        self._hasDID:            bool = False
+        self._hasData:           bool = True
+        self._dataSizeCanChange: bool = True
 
-        self.did = did
-        self.data = data
+        self._autoALFID: bool = autoALFID
+        self.dfid             = dfid
+        self.alfid            = alfid
+        self.maddr            = maddr
+        self.msize            = msize
+
+        self._dataSize: int = len(self.data)
+
+    @property
+    def dfid(self) -> int:
+        return int.from_bytes(self._dfid, 'big')
+
+    @dfid.setter
+    def dfid(self, dfid: int | bytes) -> None:
+        self._dfid = sanitize_msg_param(dfid, 1)
+    
+    @property
+    def alfid(self) -> int:
+        return int.from_bytes(self._alfid, 'big')
+
+    @alfid.setter
+    def alfid(self, alfid: int | bytes) -> None:
+        self._alfid = sanitize_msg_param(alfid, 1)
+
+    @property
+    def maddr(self) -> int:
+        return int.from_bytes(self._maddr, 'big')
+
+    @maddr.setter
+    def maddr(self, maddr: int | bytes) -> None:
+        maddr = sanitize_msg_param(maddr)
+        if(self._autoALFID == True): # Auto-calculating alfid
+            if(maddr.__len__() > 0x0f):
+                raise ValueError(F"maddr length must be less than 16 bytes, got {maddr.__len__()} bytes: {maddr}")
+            self.alfid = (self.alfid & 0xf0) | (maddr.__len__() & 0x0f)
+        self._maddr = maddr
+
+    @property
+    def msize(self) -> int:
+        return int.from_bytes(self._msize, 'big')
+
+    @msize.setter
+    def msize(self, msize: int | bytes) -> None:
+        msize = sanitize_msg_param(msize)
+        if(self._autoALFID == True): # Auto-calculating alfid
+            if(msize.__len__() > 0x0f):
+                raise ValueError(F"msize length must be less than 16 bytes, got {msize.__len__()} bytes: {msize}")
+            self.alfid = (self.alfid & 0x0f) | ((msize.__len__() & 0x0f) << 4)
+        self._msize = msize
+    
+    @property
+    def data(self) -> bytes:
+        """
+        Concatenates the request's properties to form the data field.
+        """
+        return sanitize_msg_param(self._dfid) + sanitize_msg_param(self._alfid) + sanitize_msg_param(self._maddr) + sanitize_msg_param(self._msize)
 
 
 class RequestUploadResponse(UDSMessage):

--- a/Test/test_1_uds_services.py
+++ b/Test/test_1_uds_services.py
@@ -938,6 +938,15 @@ def test_RequestUploadRequest_Errors():
         msg = RequestUploadRequest(dfid=dfid, alfid=alfid, maddr=maddr, msize=msize, autoALFID=autoALFID)
         RequestUploadRequest_testActions(msg=msg, dfid=dfid, alfid=alfid, maddr=maddr, msize=msize, autoALFID=autoALFID)
 
+    dfid = b'\x00'
+    alfid = b'\x22'
+    maddr = b'\xDD\xEE'
+    msize = b'\xBB\xCC\xBB\xCC\xBB\xCC\xBB\xCC\xBB\xCC\xBB\xCC\xBB\xCC\xBB\xCC'
+    autoALFID = True
+    with pytest.raises(ValueError):
+        msg = RequestUploadRequest(dfid=dfid, alfid=alfid, maddr=maddr, msize=msize, autoALFID=autoALFID)
+        RequestUploadRequest_testActions(msg=msg, dfid=dfid, alfid=alfid, maddr=maddr, msize=msize, autoALFID=autoALFID)
+
 def RequestUploadResponse_testActions(msg: RequestUploadResponse, data: bytes = b''):
     assert isinstance(msg, RequestUploadResponse)
     assert msg.sid == 0x75

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 setup(
   name = 'RP1210',
   packages = setuptools.find_packages(),
-  version = '0.0.22',
+  version = '0.0.23',
   license='MIT',
   description = 'A Python32 implementation of the RP1210C standard.',
   long_description = open('README.md').read(),


### PR DESCRIPTION
In the UDS standard, RequestDownload and RequestUpload messages do not have DIDs. This PR updates the associated classes to reflect that, and adds some extra functionality to them.

## ✨ Enhancements
- Fleshed out constructors for RequestDownloadRequest and RequestUploadRequest to enable setting each message field individually.
- Implemented automatically calculating the ALFID for RequestDownloadRequest and RequestUploadRequest. Enabled by default, but can be disabled with constructor parameters.

## 🗿 Miscellaneous
- Updated tests to reflect the changes to RequestDownload and RequestUpload.

## 👀 Checklist
- [x] Did you test your changes?
- [x] Do the unit tests all pass?
- [x] Do the examples still work?
- [x] Are there any failing workflows?
- [x] Is `version` in `setup` up-to-date?
