### PR TITLE
add a python-can interface to this RP1210 package

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Contributions welcome!
 
 **Note from the author:** I no longer work with RP1210 regularly (or at all) and have no need to work with and no access to RP1210 adapters. As such, I'm not actively updating this package anymore. Contributions and bug reports are still welcome.
 
+**This module is considered 'complete', mostly by dint of me not updating it anymore.**
+
 Some documentation and examples are available in [this repo's wiki](https://github.com/dfieschko/RP1210/wiki) and the Examples folder.
 
 This module was written and tested with Python 3.9 and 3.10, 32-bit. Older (and newer) Python versions have not been tested and may not be supported.   
@@ -15,9 +17,6 @@ This module was written and tested with Python 3.9 and 3.10, 32-bit. Older (and 
 and can thus only be loaded with 32-bit Python. A 64-bit implementation via
 [MSL-LoadLib](https://github.com/MSLNZ/msl-loadlib) is possible and may be released as a separate
 module sometime in the future.
-
-**This module is currently in alpha, and changes to core functionality may happen.** Once it hits beta,
-I will start taking care not to break people's code. Until then, expect changes. You can keep track of planned changes in the [Issues](https://github.com/dfieschko/RP1210/issues) page.
 
 Not all aspects of the RP1210C standard are fully implemented as independent features. Currently, my focus is on J1939 communication.
 Other protocols have significantly less support, but you can still access all the low-level commands via the `RP1210API` class.

--- a/RP1210/pyrp1210bridge.py
+++ b/RP1210/pyrp1210bridge.py
@@ -1,0 +1,103 @@
+import time
+from typing import Any, Optional
+
+import can
+from can import Message, CanProtocol, CanOperationError
+
+import RP1210
+
+
+class PyRP1210Bridge(can.bus.BusABC):
+    def __init__(
+        self,
+        channel: Any,
+        bitrate: int = 500_000,
+        poll_interval: float = 0.01,
+        **kwargs: object,
+    ):
+
+        self.poll_interval = poll_interval
+        self.bitrate = bitrate
+        self.dll_name, self.device_id = channel.split(":")
+        self.device_id = int(self.device_id)
+        self.channel_info = f"RP1210:{channel}"
+        self._can_protocol = CanProtocol.CAN_20
+
+        self.interface = RP1210.RP1210Client()
+        self.interface.setVendor(self.dll_name)
+        self.interface.setDevice(self.device_id)
+
+        self.interface.connect(b"CAN:Baud=" + str(self.bitrate).encode("utf-8"))
+        self.interface.setAllFiltersToPass()
+
+        super().__init__(
+            channel=channel,
+            bitrate=bitrate,
+            poll_interval=poll_interval,
+            **kwargs,
+        )
+
+    def send(self, msg: Message, timeout: Optional[float] = None) -> None:
+        arbitration_id = msg.arbitration_id.to_bytes(length=4, byteorder="big")
+        frame_bytes = b"\x01" + arbitration_id + msg.data
+        self.interface.tx(frame_bytes)
+        pass
+
+    def _recv_internal(self, timeout: Optional[float] = None):
+        start = time.monotonic()
+        msg = None
+
+        while msg is None:
+            res = self.interface.rx(buffer_size=256 + 5, blocking=False)
+
+            if res is None or len(res) == 0:
+                if timeout is not None and (time.monotonic() - start) >= timeout:
+                    return None, False
+                else:
+                    time.sleep(self.poll_interval)
+                    continue
+            else:
+                msg = res
+
+        if msg is None:
+            return None, False
+
+        timestamp = int.from_bytes(msg[0:4], "big")
+        flags = msg[4]
+
+        arbitration_id = int.from_bytes(msg[5 : 5 + 4], "big")
+
+        dlc = len(msg) - 4 - 5
+        if dlc > 0:
+            data = msg[9:]
+        else:
+            data = b""
+
+        if flags != 0xFF:
+            is_extended = bool(flags & 0x01)
+            is_remote = bool((flags >> 1) & 0x01)
+            is_error = bool((flags >> 2) & 0x01)
+        else:
+            is_extended = True
+            is_remote = False
+            is_error = False
+
+        if is_error:
+            raise CanOperationError("RP1210 error reported")
+
+        msg = Message(
+            arbitration_id=arbitration_id,
+            is_extended_id=is_extended,
+            timestamp=timestamp,
+            is_remote_frame=is_remote,
+            dlc=dlc,
+            data=data,
+            channel=self.channel_info,
+            is_rx=True,
+        )
+
+        return msg, False
+
+    def shutdown(self) -> None:
+        super().shutdown()
+        self.interface.disconnect()

--- a/setup.py
+++ b/setup.py
@@ -2,33 +2,38 @@ from distutils.core import setup
 import setuptools
 
 setup(
-  name = 'RP1210',
-  packages = setuptools.find_packages(),
-  version = '0.0.26',
-  license='MIT',
-  description = 'A Python32 implementation of the RP1210C standard.',
-  long_description = open('README.md').read(),
-  long_description_content_type = 'text/markdown',
-  author = 'Darius Fieschko',
-  author_email = 'dfieschko@gmail.com',
-  url = 'https://github.com/dfieschko/RP1210',
-  keywords = ['RP1210', 'RP1210C', 'J1939', 'CAN', 'UDS'],
-  install_requires=[],
-  classifiers=[
-    'Development Status :: 3 - Alpha',      # "3 - Alpha", "4 - Beta" or "5 - Production/Stable"
-    'Intended Audience :: Developers',
-    'Topic :: Software Development :: Libraries :: Python Modules',
-    'License :: OSI Approved :: MIT License',
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
-    'Programming Language :: Python :: 3.10',
-    'Programming Language :: Python :: 3.11',
-    'Operating System :: Microsoft :: Windows'
-  ],
-  project_urls = {
-    'Wiki' : 'https://github.com/dfieschko/RP1210/wiki',
-    'Issues' : 'https://github.com/dfieschko/RP1210/issues',
-    'Discussions' : 'https://github.com/dfieschko/RP1210/discussions'
-  },
-  python_requires='>=3.9'
+    name="RP1210",
+    packages=setuptools.find_packages(),
+    version="0.0.26",
+    license="MIT",
+    description="A Python32 implementation of the RP1210C standard.",
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
+    author="Darius Fieschko",
+    author_email="dfieschko@gmail.com",
+    url="https://github.com/dfieschko/RP1210",
+    keywords=["RP1210", "RP1210C", "J1939", "CAN", "UDS"],
+    install_requires=["python-can~=4.3.1"],
+    classifiers=[
+        "Development Status :: 3 - Alpha",  # "3 - Alpha", "4 - Beta" or "5 - Production/Stable"
+        "Intended Audience :: Developers",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Operating System :: Microsoft :: Windows",
+    ],
+    project_urls={
+        "Wiki": "https://github.com/dfieschko/RP1210/wiki",
+        "Issues": "https://github.com/dfieschko/RP1210/issues",
+        "Discussions": "https://github.com/dfieschko/RP1210/discussions",
+    },
+    python_requires=">=3.9",
+    entry_points={
+        "can.interface": [
+            "rp1210=RP1210.pyrp1210bridge:PyRP1210Bridge",
+        ]
+    },
 )


### PR DESCRIPTION
## ✨ Enhancements
with this any python-can tool can use a RP1210 adapter


## 👀 Checklist
- [x] Did you test your changes?

yes; with scapy.automotive and can.logger using both `NXULNK32:1` and `DGDPA5MA` as `-c` arguments to `-i rp2110`

- [X] Do the unit tests all pass? Y
- [X] Do the examples still work? Y
- [X] Are there any failing workflows? N
- [ ] Is `version` in `setup` up-to-date? I don't know... I guess if you accept this then it would probably be another version bump...
